### PR TITLE
fix npm syntax package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "vite-svg-loader": "^3.6.0",
     "vue": "^3.2.45",
     "vue-tsc": "^0.34.13",
-    "webpack-i18n-tools": "https://github.com/nimiq/webpack-i18n-tools#commit=5d8b1b5201ad63c5144dc3ccc0c706e107075c34"
+    "webpack-i18n-tools": "https://github.com/nimiq/webpack-i18n-tools#5d8b1b5201ad63c5144dc3ccc0c706e107075c34"
   },
   "postcss": {
     "plugins": {


### PR DESCRIPTION
The syntax `commit=` to refer to a github commit in the `package.json` is not supported by `npm` and breaks installation of this library.

Therefore I propose this equivalent syntax which works equally well for `npm` and `yarn`